### PR TITLE
fix(workflows/release): add action step to run build

### DIFF
--- a/.changeset/curly-birds-fetch.md
+++ b/.changeset/curly-birds-fetch.md
@@ -1,0 +1,5 @@
+---
+'@tylerapfledderer/chakra-ui-typescale': patch
+---
+
+Add github action step to run build for release workflow

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,6 +23,9 @@ jobs:
       - name: Install Dependencies
         run: npm i
 
+      - name: Build packages
+        run: npm run build
+
       - name: Create Release Pull Request or Publish to npm
         id: changesets
         uses: changesets/action@v1

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "format": "prettier --write \"src/**/*.ts\" \"src/**/*.js\"",
     "lint": "tslint -p tsconfig.json",
     "changeset:gen": "npx changeset",
-    "release": "npx changeset publish"
+    "release": "changeset publish"
   },
   "keywords": [
     "chakra-ui",


### PR DESCRIPTION
Closes #1 

Add a step for `npm run build` as the current release workflow does not contain any explicit action to create the `dist` folder.