### PR TITLE
chore(README): add badges for license and language grade

### DIFF
--- a/.changeset/light-needles-argue.md
+++ b/.changeset/light-needles-argue.md
@@ -1,0 +1,5 @@
+---
+'@tylerapfledderer/chakra-ui-typescale': patch
+---
+
+Add README badges for license and language grade

--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # withTypeScale for ChakraUI
 
+![NPM Package License](https://img.shields.io/npm/l/@tylerapfledderer/chakra-ui-typescale?style=for-the-badge)
+![LGTM Grade](https://img.shields.io/lgtm/grade/javascript/github/tylerapfledderer/chakra-ui-typescale?style=for-the-badge)
+
 A theme extension for ChakraUI to generate a type scale for use with the `Text`
 and `Heading` components.
 


### PR DESCRIPTION
Display shield badges for the MIT license and the LGTM language grade