### PR TITLE
fix(with-typescale): provide correct import for vertical-space

### DIFF
--- a/.changeset/olive-llamas-reflect.md
+++ b/.changeset/olive-llamas-reflect.md
@@ -1,0 +1,5 @@
+---
+'@tylerapfledderer/chakra-ui-typescale': patch
+---
+
+Fix import for `vertical-space` into `with-typescale`

--- a/src/with-typescale.ts
+++ b/src/with-typescale.ts
@@ -1,7 +1,7 @@
 import { mergeThemeOverride, ThemeExtension } from '@chakra-ui/react';
 import { toPrecision } from '@chakra-ui/utils';
 import { SystemStyleObject } from '@chakra-ui/theme-tools';
-import verticalSpace from 'vertical-space';
+import verticalSpace from './vertical-space';
 
 type WithTypeScaleProps = {
   /**


### PR DESCRIPTION
Fix issue where the `vertical-space` file was not imported correctly into `with-typescale`.