### PR TITLE
fix(with-typescale): provide direct value for base styles.

### DIFF
--- a/.changeset/few-phones-drum.md
+++ b/.changeset/few-phones-drum.md
@@ -1,0 +1,5 @@
+---
+'@tylerapfledderer/chakra-ui-typescale': patch
+---
+
+Fix generated component base styles where the default values for `marginBottom` should come directly from the `verticalSpace` function return instead of calling the token strings.

--- a/src/with-typescale.ts
+++ b/src/with-typescale.ts
@@ -88,22 +88,23 @@ export function withTypeScale(props: WithTypeScaleProps): ThemeExtension {
   );
 
   return (theme) => {
+    const vertical = verticalSpace(lineHeight);
     return mergeThemeOverride(theme, {
       fontSizes: fontSizesObj,
       space: {
-        vertical: verticalSpace(lineHeight),
+        vertical,
       },
       components: {
         Heading: {
           baseStyle: {
-            marginBottom: 'vertical.2',
+            marginBottom: vertical[2],
           },
           sizes: headingSizesObj,
         },
         Text: {
           baseStyle: {
             lineHeight: headingSizesObj.base.lineHeight,
-            marginBottom: 'vertical.2',
+            marginBottom: vertical[2],
           },
         },
       },


### PR DESCRIPTION
Fix generated component base styles where the default values for `marginBottom` should come directly from the `verticalSpace` function return instead of calling the token strings.