### PR TITLE
chore: update imports

### DIFF
--- a/.changeset/twelve-timers-visit.md
+++ b/.changeset/twelve-timers-visit.md
@@ -1,0 +1,9 @@
+---
+'@tylerapfledderer/chakra-ui-typescale': patch
+---
+
+Update dependencies, import(s) and remove `@chakra-ui/theme-tools` dependency.
+
+- Dependecy versions have been bumped
+- Removed `@chakra-ui/theme-tools` dependency as it is no longer needed to import `SystemStyleObject`
+- `SystemStyleObject` is now imported from `@chakra-ui/react`

--- a/apps/nextjs/package-lock.json
+++ b/apps/nextjs/package-lock.json
@@ -2019,7 +2019,7 @@
     "node_modules/@tylerapfledderer/chakra-ui-typescale": {
       "version": "1.2.0",
       "resolved": "file:../../../tylerapfledderer-chakra-ui-typescale-1.2.0.tgz",
-      "integrity": "sha512-0GoS1x6Wcslmw7aMEwalXgiBg0weDPsa1BQpj95KrD/cPFUADncn0Uj7Y0rw29SiRhY1EEKfNqCbQcXhKdTwuQ==",
+      "integrity": "sha512-1cStxMoLqwAplWl7pAyAwSlf4Ts2OMgMdJOHxfjcc6xNMeK9OcifimRXHhOPKiZDLbGuLbW6F17giS68ifqLKQ==",
       "license": "MIT",
       "dependencies": {
         "@chakra-ui/react": "^2.2.1",
@@ -6699,7 +6699,7 @@
     },
     "@tylerapfledderer/chakra-ui-typescale": {
       "version": "file:..\\..\\..\\tylerapfledderer-chakra-ui-typescale-1.2.0.tgz",
-      "integrity": "sha512-0GoS1x6Wcslmw7aMEwalXgiBg0weDPsa1BQpj95KrD/cPFUADncn0Uj7Y0rw29SiRhY1EEKfNqCbQcXhKdTwuQ==",
+      "integrity": "sha512-1cStxMoLqwAplWl7pAyAwSlf4Ts2OMgMdJOHxfjcc6xNMeK9OcifimRXHhOPKiZDLbGuLbW6F17giS68ifqLKQ==",
       "requires": {
         "@chakra-ui/react": "^2.2.1",
         "@chakra-ui/theme-tools": "^2.0.2",

--- a/package.json
+++ b/package.json
@@ -54,7 +54,6 @@
   },
   "dependencies": {
     "@chakra-ui/react": "^2.2.1",
-    "@chakra-ui/theme-tools": "^2.0.2",
     "@chakra-ui/utils": "^2.0.2",
     "@changesets/cli": "^2.23.0"
   }

--- a/src/with-typescale.ts
+++ b/src/with-typescale.ts
@@ -1,6 +1,9 @@
-import { mergeThemeOverride, ThemeExtension } from '@chakra-ui/react';
+import {
+  mergeThemeOverride,
+  SystemStyleObject,
+  ThemeExtension,
+} from '@chakra-ui/react';
 import { toPrecision } from '@chakra-ui/utils';
-import { SystemStyleObject } from '@chakra-ui/theme-tools';
 import verticalSpace from './vertical-space';
 
 type WithTypeScaleProps = {


### PR DESCRIPTION
- Dependecy versions have been bumped
- Removed `@chakra-ui/theme-tools` dependency as it is no longer needed to import `SystemStyleObject`
- `SystemStyleObject` is now imported from `@chakra-ui/react`