### PR TITLE
feat: use `clamp()` optionally for `Heading`

### DIFF
--- a/.changeset/itchy-keys-tap.md
+++ b/.changeset/itchy-keys-tap.md
@@ -2,7 +2,7 @@
 '@tylerapfledderer/chakra-ui-typescale': minor
 ---
 
-Add option to use `clamp()` functionality for `Heading` sizes
+Add option to use `clamp()` functionality for `Heading` sizes via the prop `isClamped`.
 
 > Defaults to `false`
 

--- a/.changeset/itchy-keys-tap.md
+++ b/.changeset/itchy-keys-tap.md
@@ -1,0 +1,22 @@
+---
+'@tylerapfledderer/chakra-ui-typescale': minor
+---
+
+Add option to use `clamp()` functionality for `Heading` sizes
+
+> Defaults to `false`
+
+- Adds ability to toggle between the use of the CSS `clamp()` function or the use of Chakra's breakpoint array feature for the `Heading` component's `sizes` object. Affects both the font sizes and line heights generated.
+- Instead of `true` to enable `clamp()`, can accept an object to replace the default sizes (in pixels) with newly defined min and/or max screen sizes to clamp to.
+
+```ts
+withTypeScale({
+  scale: 1.25,
+  lineHeight: 1.45,
+  isClamped: { minW: 300, maxW: 1200 },
+});
+```
+
+- The README file is updated to reflect the new functionality, along with other minor changes to the documentation.
+
+> NOTE: This is not a breaking change, as the clamp functionality is not enabled by default, and will not affect current projects. Enabling the functionality, however, may require adjustments as it could unexpectedly break UI layouts.

--- a/README.md
+++ b/README.md
@@ -6,24 +6,24 @@
 A theme extension for ChakraUI to generate a type scale for use with the `Text`
 and `Heading` components.
 
-> This is a project for personal use, but feel free to try it out in your own
-> Chakra projects. Any feedback and help to make the extension better is always
-> welcome! 😁
+> Any feedback and help to make the extension better is always welcome! 😁
 
 ## Installation
 
 ```bash
 npm i @tylerapfledderer/chakra-ui-typescale
+```
 
 # or
 
+```bash
 yarn add @tylerapfledderer/chakra-ui-typescale
 ```
 
 ## Usage
 
-`withTypeScale` as an extension is included as an additional argument to the
-`extendTheme`
+Because `withTypeScale` is a theme extension, it is included as an additional argument to the
+`extendTheme`, along with any other extension that may be used.
 
 ```ts
 import { withTypeScale } from '@tylerapfledderer/chakra-ui-typescale';
@@ -38,6 +38,8 @@ const customTheme = extendTheme(
 export default customTheme;
 ```
 
+### `scale` prop
+
 It requires one prop, referred to as the `scale`. It is a unitless number value,
 with the lowest common value usually `1.067` (or the "Minor Second") up to
 `1.618` (the "Golden Ratio") and any other scale or custom value in between.
@@ -45,7 +47,7 @@ There is a [type-scale generator](https://type-scale.com/) by Jeremy Church for
 reference. (Scroll down on the page to see his suggestions on picking a scale
 value!)
 
-### `lineHeight` prop
+### `lineHeight` prop _(optional)_
 
 An optional prop is the `lineHeight` which is also passed as a unitless number
 value, but renders as a `rem` value. It needs to be unitless to allow for
@@ -63,6 +65,25 @@ This `lineHeight` value is also used to generate a new set of `space` theme toke
 > To learn more on vertical rhythm check out the discussion from designer Matej
 > Latin on his site
 > [BetterWebType.com](https://betterwebtype.com/articles/2018/10/15/rhythm-in-web-typography/#vertical-rhythm)
+
+### `isClamped` prop _(optional)_
+
+> Defaults to `false`
+
+This prop toggles between the use of custom `clamp()` functionality, or Chakra's breakpoint array feature. This is applied to the `Heading` component font sizes and line heights generated in the `sizes` theme object.
+
+- If `true` a custom `clamp()` function is used so the font sizes and line heights are scaled gradually throughout screen sizes instead of breakpoints. The minimum screen size is `375px` and the maximum screen size is `640px`.
+  - Instead of true, you can also defined an object to set a `minW` and/or `maxW` in pixels
+
+```ts
+withTypeScale({
+  scale: 1.25,
+  lineHeight: 1.45,
+  isClamped: { minW: 300, maxW: 1200 },
+});
+```
+
+- If `false` Chakra's breakpoint array is used to declare change of the font sizes and line heights via a sensible breakpoint. (breakpoint used is `min-width` 48em, aka `md`). For more information, see Chakra UI's page on [Responsive Styles](https://chakra-ui.com/docs/styled-system/responsive-styles)
 
 ## Return Object
 
@@ -111,8 +132,5 @@ So use the even token numbers if you want to use multiples of the line height!
 
 ## Future Considerations
 
-- Testing with Capsize and the
-  [chakra-capsize package](https://github.com/ceteio/chakra-capsize) to find any
-  impact with its implementation.
 - As the extension gets used, there may be discovery of other ways to generate
   the values more effeciently or with more flexibility.

--- a/README.md
+++ b/README.md
@@ -70,9 +70,9 @@ This `lineHeight` value is also used to generate a new set of `space` theme toke
 
 > Defaults to `false`
 
-This prop toggles between the use of custom `clamp()` functionality, or Chakra's breakpoint array feature. This is applied to the `Heading` component font sizes and line heights generated in the `sizes` theme object.
+This prop toggles between the use of custom functionality with the CSS `clamp()` function, or Chakra's breakpoint array feature. This is applied to the `Heading` component font sizes and line heights generated in the `sizes` theme object.
 
-- If `true` a custom `clamp()` function is used so the font sizes and line heights are scaled gradually throughout screen sizes instead of breakpoints. The minimum screen size is `375px` and the maximum screen size is `640px`.
+- If `true` a custom function with `clamp()` is used so the font sizes and line heights are scaled gradually throughout screen sizes instead of breakpoints. The minimum screen size is `375px` and the maximum screen size is `640px`.
   - Instead of true, you can also defined an object to set a `minW` and/or `maxW` in pixels
 
 ```ts

--- a/src/utils/clamp-font.ts
+++ b/src/utils/clamp-font.ts
@@ -1,0 +1,26 @@
+// Based on CSS Tricks walkthrough of calculating the clamp for font sizes: https://css-tricks.com/linearly-scale-font-size-with-css-clamp-based-on-the-viewport/
+
+import { toPrecision } from '@chakra-ui/utils';
+
+type ClampFontProps = {
+  minSize: number;
+  maxSize: number;
+  minVW?: number;
+  maxVW?: number;
+};
+
+export function clampFont(props: ClampFontProps) {
+  const { minSize, maxSize, minVW = 375, maxVW = 640 } = props;
+
+  const minVWtoRem = minVW / 16;
+  const maxVWtoRem = maxVW / 16;
+
+  const slope = (maxSize - minSize) / (maxVWtoRem - minVWtoRem);
+  const yAxisDirection = -minVWtoRem * slope + minSize;
+  const preferredVal = `${toPrecision(yAxisDirection, 2)}rem + ${toPrecision(
+    slope * 100,
+    2,
+  )}vw`;
+
+  return `clamp(${minSize}rem, ${preferredVal}, ${maxSize}rem)`;
+}

--- a/src/with-typescale.ts
+++ b/src/with-typescale.ts
@@ -25,15 +25,17 @@ type WithTypeScaleProps = {
    * If true, the font sizes and line heights generated will use the `clamp()` function
    * instead of using an array with Chakra's breakpoint checking.
    *
-   * NOTE: This is only applied to the `sizes` for the `Heading` component. The `Text` component theme does not use `sizes`.
+   * Can also accept an object (making it truthy) to set the minimum and/or maximum viewport widths to clamp at. (`minVW` and `maxVW`)
    *
-   * @default true
+   * NOTE: This is only applied to the `sizes` theme object for the `Heading` component. The `Text` component theme does not use `sizes`.
+   *
+   * @default false
    */
-  isClamped?: boolean;
+  isClamped?: boolean | { minVW?: number; maxVW?: number };
 };
 
 export function withTypeScale(props: WithTypeScaleProps): ThemeExtension {
-  const { scale, lineHeight = 1.5, isClamped = true } = props;
+  const { scale, lineHeight = 1.5, isClamped = false } = props;
 
   if (typeof lineHeight !== 'number')
     throw Error(
@@ -82,11 +84,16 @@ export function withTypeScale(props: WithTypeScaleProps): ThemeExtension {
     return i;
   });
 
+  // Check if the `isClamped` prop is an object with min and/or max values
+  const isClampedObj = typeof isClamped === 'object' ? isClamped : undefined;
+
   const scaledFontSize = (curr: string, currIndex: number) =>
     isClamped
       ? clampFont({
           minSize: sizesArr[currIndex - 1],
           maxSize: sizesArr[currIndex],
+          minVW: isClampedObj?.minVW,
+          maxVW: isClampedObj?.maxVW,
         })
       : [SIZE_TOKENS[currIndex - 1] || curr, null, curr];
 
@@ -95,6 +102,8 @@ export function withTypeScale(props: WithTypeScaleProps): ThemeExtension {
       ? clampFont({
           minSize: lineHeightArr[currIndex - 1],
           maxSize: lineHeightArr[currIndex],
+          minVW: isClampedObj?.minVW,
+          maxVW: isClampedObj?.maxVW,
         })
       : [
           lineHeightArr[currIndex - 1] + 'rem',


### PR DESCRIPTION
Closes #40

This PR adds the `clamp()` functionality for both font sizes and line heights generated in the `sizes` theming for the `Heading` component.

The boolean prop `isClamped` is added to be able to toggle between the clamp and Chakra's breakpoint array so the user can choose either allow for the smooth size change through various screen sizes, or change the font size based on a sensible breakpoint. This prop defaults to `true`.

> NOTE: This does not included theming with the `Text` component because the `sizes` object is not being generated. May be considered in a future PR.
> 
> The referenced issue notes including this to the `fontSizes` theme object. This inclusion will be suspended, either indefinitely or opened in a new issue to be added. (Currently considering the later)