### PR TITLE
refactor: update syntax

### DIFF
--- a/.changeset/stupid-plums-relax.md
+++ b/.changeset/stupid-plums-relax.md
@@ -1,0 +1,7 @@
+---
+'@tylerapfledderer/chakra-ui-typescale': patch
+---
+
+Refactor various minor syntax
+
+Simplify the `sizesArr` declaration using the `map()` function.

--- a/src/vertical-space.ts
+++ b/src/vertical-space.ts
@@ -6,14 +6,13 @@
 const verticalSpace = (base: number) => {
   const TOKEN_QUANTITY = 13;
 
-  const spaces = Array.from<number>({
+  return Array.from<number>({
     length: TOKEN_QUANTITY,
   }).reduce<{ [x: number]: string }>((acc, _, currIndex) => {
     const tokenKey = currIndex + 1;
     // `(base / 2)` to keep whole number keys with multiples of half of the line height value.
     return { ...acc, [tokenKey]: `${((base / 2) * tokenKey).toFixed(3)}rem` };
   }, {});
-  return spaces;
 };
 
 export default verticalSpace;

--- a/src/with-typescale.ts
+++ b/src/with-typescale.ts
@@ -50,13 +50,12 @@ export function withTypeScale(props: WithTypeScaleProps): ThemeExtension {
   /**
    * Holds the generated font sizes
    */
-  const sizesArr: number[] = [];
-  for (let i = 0; i < SIZE_TOKENS.length; i++) {
-    const value =
-      SIZE_TOKENS[i] === 'base' ? '1' : toPrecision(scale ** (i - 1), 3);
+  const sizesArr: number[] = SIZE_TOKENS.map((token, index) => {
+    const value = token === 'base' ? '1' : toPrecision(scale ** (index - 1), 3);
 
-    sizesArr.push(parseFloat(value));
-  }
+    return parseFloat(value);
+  });
+
   /**
    * The key:value pairs of the token abbreviation and related generated font size
    */

--- a/src/with-typescale.ts
+++ b/src/with-typescale.ts
@@ -53,7 +53,7 @@ export function withTypeScale(props: WithTypeScaleProps): ThemeExtension {
   const sizesArr: number[] = [];
   for (let i = 0; i < SIZE_TOKENS.length; i++) {
     const value =
-      SIZE_TOKENS[i] === 'base' ? '1' : toPrecision(Math.pow(scale, i - 1), 3);
+      SIZE_TOKENS[i] === 'base' ? '1' : toPrecision(scale ** (i - 1), 3);
 
     sizesArr.push(parseFloat(value));
   }
@@ -62,7 +62,7 @@ export function withTypeScale(props: WithTypeScaleProps): ThemeExtension {
    */
   const fontSizesObj: Record<string, string> = SIZE_TOKENS.reduce(
     (prev, curr, currIndex) => {
-      return { ...prev, [curr]: sizesArr[currIndex] + 'rem' };
+      return { ...prev, [curr]: `${sizesArr[currIndex]}rem` };
     },
     {},
   );
@@ -76,7 +76,7 @@ export function withTypeScale(props: WithTypeScaleProps): ThemeExtension {
    * If the base `lineHeight` is 24px (1.5rem), then if the given font size is
    * 32px, then its line height should be 48px, taking up two "rows"
    */
-  let lineHeightArr = sizesArr.map((size) => {
+  const lineHeightArr = sizesArr.map((size) => {
     let i = lineHeight;
     while (i < size) {
       i += lineHeight;
@@ -106,9 +106,9 @@ export function withTypeScale(props: WithTypeScaleProps): ThemeExtension {
           maxVW: isClampedObj?.maxVW,
         })
       : [
-          lineHeightArr[currIndex - 1] + 'rem',
+          `${lineHeightArr[currIndex - 1]}rem`,
           null,
-          lineHeightArr[currIndex] + 'rem',
+          `${lineHeightArr[currIndex]}rem`,
         ];
 
     /**
@@ -116,12 +116,9 @@ export function withTypeScale(props: WithTypeScaleProps): ThemeExtension {
      * return just that value.
      * Else, return the scale.
      */
-    const lineHeightVal =
-      lineHeightArr[currIndex - 1] === lineHeightArr[currIndex]
-        ? lineHeightArr[currIndex] + 'rem'
-        : lineHeightScale;
-
-    return lineHeightVal;
+    return lineHeightArr[currIndex - 1] === lineHeightArr[currIndex]
+      ? `${lineHeightArr[currIndex]}rem`
+      : lineHeightScale;
   };
 
   const headingSizesObj: Record<string, SystemStyleObject> = SIZE_TOKENS.reduce(
@@ -132,7 +129,7 @@ export function withTypeScale(props: WithTypeScaleProps): ThemeExtension {
           fontSize: currIndex < 2 ? curr : scaledFontSize(curr, currIndex),
           lineHeight:
             currIndex < 2
-              ? lineHeightArr[currIndex] + 'rem'
+              ? `${lineHeightArr[currIndex]}rem`
               : scaledLineHeight(currIndex),
         },
       };


### PR DESCRIPTION
- Refactor various minor syntax
- Simplify the `sizesArr` declaration using the `map()` function.